### PR TITLE
updating gvcf_regions.py to support when gVCF type is zipped

### DIFF
--- a/gvcf_regions.py
+++ b/gvcf_regions.py
@@ -152,6 +152,8 @@ def gvcf_regions(gvcf, unreported_is_called, ignore_phrases,
 
     region_CHROM = ''
     for line in g:
+        if isinstance(line, bytes):
+            line = line.decode("utf-8") 
         # filter out header and lines with ignore phrases
         if not is_header(line) and is_considered(line, ignore_phrases):
             fields = line.strip().split('\t')


### PR DESCRIPTION
I noticed a bug, that if a gVCF is provided in gzipped format, the code crashes, giving error: 
```
Traceback (most recent call last):
  File "/home/alex/Documents/curii/bugfix/gvcf_regions/gvcf_regions.py", line 296, in <module>
    gvcf_regions(*all_par)
  File "/home/alex/Documents/curii/bugfix/gvcf_regions/gvcf_regions.py", line 156, in gvcf_regions
    if not is_header(line) and is_considered(line, ignore_phrases):
  File "/home/alex/Documents/curii/bugfix/gvcf_regions/gvcf_regions.py", line 10, in is_header
    return line.startswith('#')
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```
This is because when `g` is read-in using `gzip.open(gvcf)` it is a type `gzip.GzipFile`, and each line in it is actually class bytes, not a string.

I fixed this by adding 
```
if isinstance(line, bytes):
            line = line.decode("utf-8") 
```
when it iterates through `g`.